### PR TITLE
Fix intrinsic valuation (bug B) + check_exits_daily; re-pin reproduction; add invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,26 @@ anchored on the commit hash that introduced the change.
   (the argument still overrides per-run). The global default remains
   ``False``.
 
+### Invariants / defense-in-depth
+- **Optional runtime self-checks (`assert_invariants`).** New
+  `BacktestEngine.assert_invariants` attribute (and `assert_invariants`
+  config key; default ``False``, zero cost when off) turns on two
+  in-engine guards that fail the run loudly on violation:
+  - *Class A — cash flow:* on every option exit, the change in portfolio
+    cash must equal realized P&L net of commission, computed
+    independently of the mutation. Catches the "free puts" regression
+    (crediting full proceeds without returning the externally-funded
+    entry cost). A cash-conservation check is the right shape for this
+    class — a per-trade cash-flow bug unbalances the ledger.
+  - *Class B — valuation:* when an unquoted (expired/missing) contract
+    falls back to intrinsic value, that value must equal the
+    unadjusted-spot intrinsic, recomputed independently. Catches a
+    regression back to the adjusted close. A cash check cannot see this
+    class — both proceeds and mark use the same wrong price, so the
+    ledger stays balanced; it needs its own valuation guard.
+  Exercised by ``tests/bench/test_invariants.py::TestRuntimeInvariantChecks``
+  across the budget configurations where both bugs originally lived.
+
 ### Budget API clarification
 - ``options_budget_pct`` is **per-rebalance**, not annual. On monthly
   rebalancing, ``options_budget_pct = 0.033`` means 3.3% of NAV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ anchored on the commit hash that introduced the change.
   falls back to it, so the attribute and the explicit argument agree
   (the argument still overrides per-run). The global default remains
   ``False``.
+- **`rebalance_stocks_on_exit` is now reachable from Python.** The Rust
+  core already supported redeploying freed cash into stocks immediately
+  after a daily option exit (monetize-and-reinvest), but the flag was
+  never passed through from `BacktestEngine`, so it was dead. Exposed as
+  `BacktestEngine.rebalance_stocks_on_exit` (default ``False``; only
+  meaningful with `check_exits_daily=True`).
 
 ### Invariants / defense-in-depth
 - **Optional runtime self-checks (`assert_invariants`).** New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,54 @@ anchored on the commit hash that introduced the change.
   ``docs/PRE_FIX_REGIME_SWEEP.md`` and ``docs/POST_FIX_REGIME_SWEEP.md``.
   ``tests/test_known_bugs.py`` removed.
 
+- **Option intrinsic value now uses the unadjusted close (valuation
+  bug B).** When a contract is not quoted on a given day (expired or
+  missing from the chain), the engine falls back to the option's
+  intrinsic value. Previously it computed intrinsic from the
+  dividend-*adjusted* close (``stocks_price`` → ``adjClose``) against
+  the raw (unadjusted) strike. Because adjusted closes are lower than
+  raw closes in the past, this manufactured phantom intrinsic value
+  for any expired put whose strike sat inside the adjustment gap. The
+  engine now carries the unadjusted close (``close``) alongside the
+  adjusted close and uses it for intrinsic value; stock capital / P&L
+  still uses the adjusted close. A missing spot now yields $0 intrinsic
+  (untradeable) rather than ``strike`` from a 0.0 spot. New
+  ``stocks_unadj_price`` schema key (defaults to ``adjClose`` for
+  back-compat). Unlike the cash-flow fix above, this is a *valuation*
+  bug: both the exit proceeds and the held mark-to-market used the same
+  wrong number, so the books stayed balanced — a cash-conservation
+  check cannot see it, which is why it needs its own guard.
+
+  Effect: configurations that let contracts reach the intrinsic
+  fallback (profit-taking, shorter DTE, closer-to-ATM puts, or any run
+  with ``check_exits_daily=False``) lose phantom value. The article's
+  deep-OTM 90-180 DTE config exits at real bids near DTE 14, so its
+  numbers are largely unaffected.
+
+- **``test_article_reproduction.py`` moved to true-annual budget
+  framing.** The reproduction now configures the put overlay with
+  ``options_budget_annual_pct`` (and ``check_exits_daily=True``), matching
+  the article's "X%/yr" language and ``use_external_budget``, instead of
+  the per-rebalance ``options_budget_pct``. Under the corrected engine
+  the deep-OTM overlay TRACKS SPY with a small monotonic premium drag
+  and Sharpe ≈ buy-and-hold; the earlier "overlay beats SPY / Sharpe
+  sweet spot" result was an artifact of the two bugs above. Re-pinned
+  table (annual budget, 2008-2024): 0.5%/yr 10.50%, 1.0%/yr 10.34%,
+  2.0%/yr 9.99%, 3.3%/yr 9.52% (SPY buy-and-hold 10.65%); full-period
+  max drawdown is essentially unchanged from SPY (≈ −51.9%) at these
+  budgets. The ``test_spitznagel_sweet_spot_shape`` test is replaced by
+  ``test_spitznagel_monotone_drag_and_tracking``.
+
+### Bug fixes
+- **``check_exits_daily`` set as an attribute is now honored.** It was
+  only a ``run()`` parameter (default ``False``); assigning
+  ``engine.check_exits_daily = True`` silently did nothing because
+  ``run()`` never read it. ``BacktestEngine`` now has a
+  ``check_exits_daily`` attribute and ``run(check_exits_daily=None)``
+  falls back to it, so the attribute and the explicit argument agree
+  (the argument still overrides per-run). The global default remains
+  ``False``.
+
 ### Budget API clarification
 - ``options_budget_pct`` is **per-rebalance**, not annual. On monthly
   rebalancing, ``options_budget_pct = 0.033`` means 3.3% of NAV

--- a/options_portfolio_backtester/engine/engine.py
+++ b/options_portfolio_backtester/engine/engine.py
@@ -116,6 +116,9 @@ class BacktestEngine:
         # attribute so `engine.check_exits_daily = True` is honored rather than
         # silently ignored.
         self.check_exits_daily: bool = False
+        # Enable runtime self-checks (cash-flow + valuation invariants) in the
+        # Rust engine. Off by default; intended for tests/debugging.
+        self.assert_invariants: bool = False
 
         self.options_budget_pct: float | None = None
         self.options_budget_annual_pct: float | None = None
@@ -517,6 +520,7 @@ class BacktestEngine:
             "stop_if_broke": self.stop_if_broke,
             "max_notional_pct": self.max_notional_pct,
             "check_exits_daily": check_exits_daily,
+            "assert_invariants": self.assert_invariants,
         }
 
         schema_mapping = {
@@ -702,6 +706,7 @@ class BacktestEngine:
             "stop_if_broke": self.stop_if_broke,
             "max_notional_pct": self.max_notional_pct,
             "check_exits_daily": check_exits_daily,
+            "assert_invariants": self.assert_invariants,
         }
 
         schema_mapping = {

--- a/options_portfolio_backtester/engine/engine.py
+++ b/options_portfolio_backtester/engine/engine.py
@@ -111,6 +111,11 @@ class BacktestEngine:
         self.algos = list(algos or [])
         self.stop_if_broke = stop_if_broke
         self.max_notional_pct = max_notional_pct
+        # Default exit-checking cadence. `run(check_exits_daily=...)` overrides
+        # this when passed explicitly; otherwise run() falls back to this
+        # attribute so `engine.check_exits_daily = True` is honored rather than
+        # silently ignored.
+        self.check_exits_daily: bool = False
 
         self.options_budget_pct: float | None = None
         self.options_budget_annual_pct: float | None = None
@@ -248,15 +253,20 @@ class BacktestEngine:
     def run(self, rebalance_freq: int = 0, monthly: bool = False,
             sma_days: int | None = None,
             rebalance_unit: str = 'BMS',
-            check_exits_daily: bool = False) -> pd.DataFrame:
+            check_exits_daily: bool | None = None) -> pd.DataFrame:
         """Run the backtest. Returns the trade log DataFrame.
 
         Args:
             check_exits_daily: When True, evaluate exit filters on every trading
                 day (not just rebalancing days).  Positions that match the exit
                 filter are closed and cash is updated, but no new entries or
-                stock reallocation occurs outside rebalancing days.
+                stock reallocation occurs outside rebalancing days.  When left
+                as None (the default), falls back to ``self.check_exits_daily``
+                so the attribute form is honored; pass an explicit bool to
+                override the attribute for this run.
         """
+        if check_exits_daily is None:
+            check_exits_daily = self.check_exits_daily
         self._event_log_rows = []
         for algo in self.algos:
             if hasattr(algo, "reset"):
@@ -515,6 +525,13 @@ class BacktestEngine:
             "stocks_date": stocks_date_col,
             "stocks_symbol": self._stocks_schema["symbol"],
             "stocks_price": self._stocks_schema["adjClose"],
+            # Unadjusted close for option intrinsic value (strikes are raw
+            # prices). Falls back to adjClose if the data lacks a raw close.
+            "stocks_unadj_price": (
+                self._stocks_schema["close"]
+                if "close" in self._stocks_schema
+                else self._stocks_schema["adjClose"]
+            ),
             "underlying": self._options_schema["underlying"],
             "expiration": self._options_schema["expiration"],
             "type": self._options_schema["type"],
@@ -693,6 +710,13 @@ class BacktestEngine:
             "stocks_date": stocks_date_col,
             "stocks_symbol": self._stocks_schema["symbol"],
             "stocks_price": self._stocks_schema["adjClose"],
+            # Unadjusted close for option intrinsic value (strikes are raw
+            # prices). Falls back to adjClose if the data lacks a raw close.
+            "stocks_unadj_price": (
+                self._stocks_schema["close"]
+                if "close" in self._stocks_schema
+                else self._stocks_schema["adjClose"]
+            ),
             "underlying": self._options_schema["underlying"],
             "expiration": self._options_schema["expiration"],
             "type": self._options_schema["type"],

--- a/options_portfolio_backtester/engine/engine.py
+++ b/options_portfolio_backtester/engine/engine.py
@@ -116,6 +116,10 @@ class BacktestEngine:
         # attribute so `engine.check_exits_daily = True` is honored rather than
         # silently ignored.
         self.check_exits_daily: bool = False
+        # Immediately redeploy freed cash into stocks after a daily option exit
+        # (monetize-and-reinvest), instead of waiting for the next rebalance
+        # date. Requires check_exits_daily=True to have any effect.
+        self.rebalance_stocks_on_exit: bool = False
         # Enable runtime self-checks (cash-flow + valuation invariants) in the
         # Rust engine. Off by default; intended for tests/debugging.
         self.assert_invariants: bool = False
@@ -520,6 +524,7 @@ class BacktestEngine:
             "stop_if_broke": self.stop_if_broke,
             "max_notional_pct": self.max_notional_pct,
             "check_exits_daily": check_exits_daily,
+            "rebalance_stocks_on_exit": self.rebalance_stocks_on_exit,
             "assert_invariants": self.assert_invariants,
         }
 
@@ -706,6 +711,7 @@ class BacktestEngine:
             "stop_if_broke": self.stop_if_broke,
             "max_notional_pct": self.max_notional_pct,
             "check_exits_daily": check_exits_daily,
+            "rebalance_stocks_on_exit": self.rebalance_stocks_on_exit,
             "assert_invariants": self.assert_invariants,
         }
 

--- a/rust/ob_core/src/backtest.rs
+++ b/rust/ob_core/src/backtest.rs
@@ -66,6 +66,11 @@ pub struct BacktestConfig {
     /// When true, rebalance stocks immediately after daily option exits.
     /// Allows reinvesting put profits into stocks without waiting for the next rebalance date.
     pub rebalance_stocks_on_exit: bool,
+    /// When true, run runtime self-checks (cash-flow and valuation invariants)
+    /// during the backtest and fail loudly if they are violated. Off by default
+    /// — intended for tests and debugging, not production runs. See
+    /// `check_cashflow_invariant` and `check_valuation_envelope`.
+    pub assert_invariants: bool,
 }
 
 pub struct BacktestResult {
@@ -436,6 +441,7 @@ pub fn run_backtest_with_filters(
                 $schema, rb_date, &mut $trade_rows,
                 &$config.cost_model, day_stocks,
                 externally_funded,
+                $config.assert_invariants,
             )?;
 
             // Recompute portfolio greeks from current market data after exits
@@ -557,6 +563,7 @@ pub fn run_backtest_with_filters(
                         schema, date, &mut trade_rows,
                         &config.cost_model, day_stocks,
                         externally_funded,
+                        config.assert_invariants,
                     )?;
 
                     // Immediately reinvest freed cash into stocks
@@ -738,6 +745,7 @@ pub fn run_multi_strategy(
                     schema, date, &mut trade_rows,
                     &config.cost_model, day_stocks,
                     externally_funded_phase1,
+                    config.assert_invariants,
                 )?;
             }
 
@@ -849,6 +857,7 @@ pub fn run_multi_strategy(
                             schema, date, &mut trade_rows,
                             &config.cost_model, day_stocks,
                             externally_funded_phase2,
+                            config.assert_invariants,
                         )?;
                     }
                 }
@@ -1114,6 +1123,7 @@ fn execute_exits(
     cost_model: &CostModel,
     day_stocks: Option<&DayStocks>,
     externally_funded: bool,
+    assert_invariants: bool,
 ) -> PolarsResult<()> {
     let mut to_remove = Vec::new();
 
@@ -1152,6 +1162,7 @@ fn execute_exits(
         }
 
         if should_exit {
+            let cash_before = *cash;
             let exit_cost = compute_position_exit_cost(pos, day_opts, spc, day_stocks);
             *cash -= exit_cost * pos.quantity;
 
@@ -1170,17 +1181,57 @@ fn execute_exits(
             );
             *cash -= commission;
 
+            // Class-A cash-flow invariant (bug class A — see CHANGELOG): the
+            // cash the portfolio receives on exit must equal realized P&L net
+            // of commission, NOT the full sale proceeds. `expected` is written
+            // independently of the mutations above, so a future change that
+            // drops the externally-funded basis return (the original "free
+            // puts" bug) makes `actual` diverge and fails the run loudly.
+            if assert_invariants {
+                let proceeds = -exit_cost * pos.quantity;
+                let basis_return = if externally_funded { pos.entry_cost * pos.quantity } else { 0.0 };
+                let expected = proceeds - basis_return - commission;
+                let actual = *cash - cash_before;
+                if (actual - expected).abs() > 1e-6 * (1.0 + expected.abs()) {
+                    return Err(PolarsError::ComputeError(format!(
+                        "cash-flow invariant (class A) violated on exit at date {date}: \
+                         Δcash {actual:.6} != realized P&L net commission {expected:.6} \
+                         (externally_funded={externally_funded})"
+                    ).into()));
+                }
+            }
+
             // Build trade row for exit
             let mut leg_data = Vec::new();
             for (j, leg) in legs.iter().enumerate() {
                 let exit_price_col = leg.direction.invert().price_column();
-                let price = day_opts.get_f64(&pos.leg_contracts[j], exit_price_col)
-                    .unwrap_or_else(|| {
-                        let spot = day_stocks
-                            .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
-                            .unwrap_or(0.0);
-                        intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
-                    });
+                let quoted = day_opts.get_f64(&pos.leg_contracts[j], exit_price_col);
+                let price = quoted.unwrap_or_else(|| {
+                    let spot = day_stocks
+                        .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
+                        .unwrap_or(0.0);
+                    intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
+                });
+
+                // Class-B valuation invariant (bug class B — see CHANGELOG):
+                // when the contract is NOT quoted we fall back to intrinsic
+                // value, which MUST be computed from the unadjusted spot (raw
+                // strikes vs adjusted spot manufactured phantom value). Recompute
+                // it here independently and confirm the price used matches —
+                // a regression back to the adjusted close makes them diverge.
+                if assert_invariants && quoted.is_none() {
+                    let unadj_spot = day_stocks
+                        .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
+                        .unwrap_or(0.0);
+                    let expected = intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], unadj_spot);
+                    if price < -1e-9 || (price - expected).abs() > 1e-6 * (1.0 + expected.abs()) {
+                        return Err(PolarsError::ComputeError(format!(
+                            "valuation invariant (class B) violated at date {date}: \
+                             unquoted contract {} marked at {price:.6}, expected unadjusted \
+                             intrinsic {expected:.6}", pos.leg_contracts[j]
+                        ).into()));
+                    }
+                }
                 // Cash flow sign: BUY receives (-1), SELL pays (+1)
                 let cash_sign = if leg.direction == Direction::Buy { -1.0 } else { 1.0 };
                 let cost = cash_sign * price * spc as f64;

--- a/rust/ob_core/src/backtest.rs
+++ b/rust/ob_core/src/backtest.rs
@@ -263,12 +263,26 @@ impl DayOptions {
 
 /// Stocks data for a single date — O(1) price lookups.
 struct DayStocks {
+    /// Adjusted close (total-return) prices — used for stock capital / P&L.
     prices: HashMap<String, f64>,
+    /// Unadjusted close prices — used for option intrinsic value, since
+    /// option strikes are raw (unadjusted) prices. Mixing adjusted spot
+    /// with raw strikes manufactures phantom intrinsic value for expired
+    /// contracts (the dividend-adjustment gap), which is bug class B.
+    unadj_prices: HashMap<String, f64>,
 }
 
 impl DayStocks {
     fn get_price(&self, symbol: &str) -> Option<f64> {
         self.prices.get(symbol).copied()
+    }
+
+    /// Unadjusted spot for intrinsic-value calculations. Falls back to the
+    /// adjusted price if no unadjusted column was supplied (back-compat).
+    fn get_unadj_price(&self, symbol: &str) -> Option<f64> {
+        self.unadj_prices.get(symbol)
+            .or_else(|| self.prices.get(symbol))
+            .copied()
     }
 }
 
@@ -288,6 +302,9 @@ pub struct SchemaMapping {
     pub stocks_date: String,
     pub stocks_sym: String,
     pub stocks_price: String,
+    /// Unadjusted close column, used only for option intrinsic value.
+    /// Defaults to the adjusted price column when not supplied.
+    pub stocks_unadj_price: String,
     pub underlying: String,
     pub expiration: String,
     pub option_type: String,
@@ -921,7 +938,7 @@ fn compute_balance_period_multi(
                         let price = opts.get_f64(&pos.leg_contracts[j], exit_price_col)
                             .unwrap_or_else(|| {
                                 let spot = day_stocks
-                                    .and_then(|ds| ds.get_price(&pos.leg_underlyings[j]))
+                                    .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
                                     .unwrap_or(0.0);
                                 intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
                             });
@@ -1043,6 +1060,15 @@ pub fn prepartition_data(
     let price_raw = stocks_data.column(price_col_name)?;
     let price_casted = price_raw.cast(&DataType::Float64)?;
     let price_ca = price_casted.f64()?;
+    // Unadjusted close for intrinsic value. Falls back to the adjusted price
+    // column if the unadjusted column is absent (older callers / data without
+    // a raw close), preserving prior behavior in that case.
+    let unadj_col_name = &schema.stocks_unadj_price;
+    let unadj_casted = stocks_data
+        .column(unadj_col_name)
+        .unwrap_or(price_raw)
+        .cast(&DataType::Float64)?;
+    let unadj_ca = unadj_casted.f64()?;
     let n_stocks = stocks_data.height();
 
     let mut stocks_map: HashMap<i64, DayStocks> = HashMap::with_capacity(512);
@@ -1050,10 +1076,15 @@ pub fn prepartition_data(
     for i in 0..n_stocks {
         let date_ns = extract_date_ns(stocks_date_series, i);
         if let (Some(sym), Some(price)) = (sym_ca.get(i), price_ca.get(i)) {
-            stocks_map.entry(date_ns)
-                .or_insert_with(|| DayStocks { prices: HashMap::new() })
-                .prices
-                .insert(sym.to_string(), price);
+            let entry = stocks_map.entry(date_ns)
+                .or_insert_with(|| DayStocks {
+                    prices: HashMap::new(),
+                    unadj_prices: HashMap::new(),
+                });
+            entry.prices.insert(sym.to_string(), price);
+            if let Some(unadj) = unadj_ca.get(i) {
+                entry.unadj_prices.insert(sym.to_string(), unadj);
+            }
         }
     }
 
@@ -1146,7 +1177,7 @@ fn execute_exits(
                 let price = day_opts.get_f64(&pos.leg_contracts[j], exit_price_col)
                     .unwrap_or_else(|| {
                         let spot = day_stocks
-                            .and_then(|ds| ds.get_price(&pos.leg_underlyings[j]))
+                            .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
                             .unwrap_or(0.0);
                         intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
                     });
@@ -1218,7 +1249,7 @@ fn liquidate_all_positions(
             let price = day_opts.get_f64(&pos.leg_contracts[j], exit_price_col)
                 .unwrap_or_else(|| {
                     let spot = day_stocks
-                        .and_then(|ds| ds.get_price(&pos.leg_underlyings[j]))
+                        .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
                         .unwrap_or(0.0);
                     intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
                 });
@@ -1539,7 +1570,7 @@ fn compute_balance_period(
                     let price = opts.get_f64(&pos.leg_contracts[j], exit_price_col)
                         .unwrap_or_else(|| {
                             let spot = day_stocks
-                                .and_then(|ds| ds.get_price(&pos.leg_underlyings[j]))
+                                .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[j]))
                                 .unwrap_or(0.0);
                             intrinsic_value(&pos.leg_types[j], pos.leg_strikes[j], spot)
                         });
@@ -1746,6 +1777,12 @@ fn build_result(
 /// Compute intrinsic value of an option: max(0, strike - spot) for puts,
 /// max(0, spot - strike) for calls.
 fn intrinsic_value(opt_type: &str, strike: f64, underlying_price: f64) -> f64 {
+    // No (or non-positive) spot means the underlying price is unavailable for
+    // this contract/date — treat the option as worthless rather than letting a
+    // 0.0 spot manufacture intrinsic value equal to the strike (bug class B).
+    if !(underlying_price > 0.0) {
+        return 0.0;
+    }
     if opt_type == "call" {
         (underlying_price - strike).max(0.0)
     } else {
@@ -1761,7 +1798,7 @@ fn compute_position_exit_cost(pos: &Position, day_opts: &DayOptions, spc: i64, d
         let price = day_opts.get_f64(contract, dir.invert().price_column())
             .unwrap_or_else(|| {
                 let spot = day_stocks
-                    .and_then(|ds| ds.get_price(&pos.leg_underlyings[i]))
+                    .and_then(|ds| ds.get_unadj_price(&pos.leg_underlyings[i]))
                     .unwrap_or(0.0);
                 intrinsic_value(&pos.leg_types[i], pos.leg_strikes[i], spot)
             });
@@ -1943,7 +1980,8 @@ mod tests {
 
         let mut prices = HashMap::new();
         prices.insert("SPY".to_string(), 380.0);
-        let day_stocks = DayStocks { prices };
+        // Empty unadj_prices → get_unadj_price falls back to `prices`.
+        let day_stocks = DayStocks { prices, unadj_prices: HashMap::new() };
 
         // Sell direction → exit price col is "ask" (invert of Sell = Buy → price_column = "ask")
         // cash_sign for Sell = +1

--- a/rust/ob_python/src/py_backtest.rs
+++ b/rust/ob_python/src/py_backtest.rs
@@ -263,6 +263,12 @@ pub fn parse_config_from_dict(config: &Bound<'_, PyDict>) -> PyResult<BacktestCo
         .transpose()?
         .unwrap_or(false);
 
+    let assert_invariants: bool = config
+        .get_item("assert_invariants")?
+        .map(|v| v.extract::<bool>())
+        .transpose()?
+        .unwrap_or(false);
+
     Ok(BacktestConfig {
         allocation_stocks: alloc_stocks,
         allocation_options: alloc_options,
@@ -287,6 +293,7 @@ pub fn parse_config_from_dict(config: &Bound<'_, PyDict>) -> PyResult<BacktestCo
         check_exits_daily,
         options_budget_fresh_spend,
         rebalance_stocks_on_exit,
+        assert_invariants,
     })
 }
 

--- a/rust/ob_python/src/py_backtest.rs
+++ b/rust/ob_python/src/py_backtest.rs
@@ -21,6 +21,7 @@ pub fn parse_schema(schema: &Bound<'_, PyDict>) -> PyResult<SchemaMapping> {
         stocks_date: get_str(schema, "stocks_date", "date")?,
         stocks_sym: get_str(schema, "stocks_symbol", "symbol")?,
         stocks_price: get_str(schema, "stocks_price", "adjClose")?,
+        stocks_unadj_price: get_str(schema, "stocks_unadj_price", "adjClose")?,
         underlying: get_str(schema, "underlying", "underlying")?,
         expiration: get_str(schema, "expiration", "expiration")?,
         option_type: get_str(schema, "type", "type")?,

--- a/tests/bench/test_invariants.py
+++ b/tests/bench/test_invariants.py
@@ -158,3 +158,114 @@ class TestProductionDataInvariants:
     def test_capital_never_negative(self):
         tc = self.eng.balance["total capital"]
         assert (tc >= -1.0).all()
+
+
+# ── Runtime invariant self-checks (assert_invariants flag) ─────────────
+#
+# Exercise the in-engine cash-flow (class A) and valuation (class B)
+# invariants by enabling `assert_invariants` and confirming the CORRECTED
+# engine does not trip them across the configurations where the "free puts"
+# (class A) and adjClose-intrinsic (class B) bugs originally lived. If a
+# regression reintroduces either bug the Rust engine returns an error, which
+# surfaces here as an exception and fails the test.
+
+import math as _math
+import os as _os
+
+from options_portfolio_backtester.engine.engine import BacktestEngine
+from options_portfolio_backtester.execution.cost_model import NoCosts
+from options_portfolio_backtester.execution.fill_model import MarketAtBidAsk
+from options_portfolio_backtester.core.types import OptionType as _OptType, Direction as _Dir
+from options_portfolio_backtester.strategy.strategy import Strategy as _Strategy
+from options_portfolio_backtester.strategy.strategy_leg import StrategyLeg as _Leg
+from options_portfolio_backtester.data.providers import (
+    HistoricalOptionsData as _Opts, TiingoData as _Stx,
+)
+from options_portfolio_backtester.core.types import Stock as _Stock
+
+_PROCESSED = _os.path.join(_os.path.dirname(__file__), "..", "..", "data", "processed")
+# CSV pair (not parquet): these are the date-aligned outputs the article
+# reproduction uses; the parquet carries one extra quotedate that trips the
+# engine's stock/option date-alignment assert.
+_SPY_OPTS = _os.path.join(_PROCESSED, "options.csv")
+_SPY_STX = _os.path.join(_PROCESSED, "stocks.csv")
+_needs_spy = pytest.mark.skipif(
+    not (_os.path.exists(_SPY_OPTS) and _os.path.exists(_SPY_STX)),
+    reason="needs processed SPY data: python data/fetch_data.py all --symbols SPY",
+)
+
+
+def _deep_otm_put(schema):
+    leg = _Leg("leg_1", schema, option_type=_OptType.PUT, direction=_Dir.BUY)
+    leg.entry_filter = (
+        (schema.underlying == "SPY") & (schema.dte >= 90) & (schema.dte <= 180)
+        & (schema.delta >= -0.10) & (schema.delta <= -0.02)
+    )
+    leg.entry_sort = ("delta", False)
+    leg.exit_filter = schema.dte <= 14
+    s = _Strategy(schema)
+    s.add_leg(leg)
+    s.add_exit_thresholds(profit_pct=_math.inf, loss_pct=_math.inf)
+    return s
+
+
+class TestRuntimeInvariantChecks:
+    """The corrected engine must satisfy its own cash-flow and valuation
+    invariants. These tests turn the checks on and assert no violation."""
+
+    @pytest.fixture(scope="class")
+    def spy_data(self):
+        # Load the 3.3 GB option chain once for the whole class.
+        return _Opts(_SPY_OPTS), _Stx(_SPY_STX)
+
+    def _budget_engine(self, spy_data):
+        opts, stx = spy_data
+        eng = BacktestEngine(
+            {"stocks": 1.0, "options": 0.0, "cash": 0.0},
+            initial_capital=1_000_000,
+            cost_model=NoCosts(),
+            fill_model=MarketAtBidAsk(),
+        )
+        eng.assert_invariants = True
+        eng.stocks = [_Stock("SPY", 1.0)]
+        eng.stocks_data = stx
+        eng.options_data = opts
+        eng.options_strategy = _deep_otm_put(opts.schema)
+        return eng
+
+    def test_small_dataset_invariants_hold(self):
+        # Fast self-funded-path check on the bundled small dataset: enabling the
+        # invariants must not false-positive on a standard backtest.
+        from tests.bench._test_helpers import (
+            load_small_stocks, load_small_options, ivy_stocks, buy_put_strategy,
+        )
+        opts = load_small_options()
+        eng = BacktestEngine(
+            DEFAULT_ALLOC, initial_capital=DEFAULT_CAPITAL,
+            cost_model=NoCosts(), fill_model=MarketAtBidAsk(),
+        )
+        eng.assert_invariants = True
+        eng.stocks = ivy_stocks()
+        eng.stocks_data = load_small_stocks()
+        eng.options_data = opts
+        eng.options_strategy = buy_put_strategy(opts.schema)
+        eng.run(rebalance_freq=1, rebalance_unit="BMS")
+        assert len(eng.balance) > 0
+
+    @_needs_spy
+    @pytest.mark.parametrize("annual_budget", [0.005, 0.020, 0.033])
+    def test_spy_externally_funded_annual_invariants_hold(self, spy_data, annual_budget):
+        eng = self._budget_engine(spy_data)
+        eng.options_budget_annual_pct = annual_budget
+        # No exception == both invariants held across the whole run.
+        eng.run(rebalance_freq=1, rebalance_unit="BMS", check_exits_daily=True)
+        assert len(eng.balance) > 1
+
+    @_needs_spy
+    def test_spy_per_rebalance_budget_invariants_hold(self, spy_data):
+        # The per-rebalance framing (heavier premium spend) exercises far more
+        # exits and intrinsic fallbacks — the regime where the bugs were loudest.
+        eng = self._budget_engine(spy_data)
+        eng.options_budget_pct = 0.033
+        eng.run(rebalance_freq=1, rebalance_unit="BMS", check_exits_daily=False)
+        assert len(eng.balance) > 1

--- a/tests/test_article_reproduction.py
+++ b/tests/test_article_reproduction.py
@@ -64,28 +64,35 @@ requires_data = pytest.mark.skipif(
 #
 # Article: https://federicocarrone.com/series/leptokurtic/the-tail-hedge-debate-spitznagel-is-right/
 # Parameters: DTE 90-180, delta (-0.10, -0.02), exit DTE 14, monthly rebalance,
-# external put budget (Spitznagel framing) via `options_budget_pct` —
-# per-rebalance interpretation (so 0.005 = 0.5% of NAV per month ≈ 6%/yr of
-# budget). Data window: 2008-01-02 to 2024-12-31.
+# external put budget (Spitznagel framing) expressed as an ANNUAL budget via
+# `options_budget_annual_pct` — i.e. 0.005 = 0.5% of NAV per year, matching the
+# article's "X%/yr" language. Exits are checked daily (`check_exits_daily=True`)
+# so puts close at real bids around DTE 14 rather than expiring into the
+# intrinsic fallback. Data window: 2008-01-02 to 2024-12-31.
 #
-# Numbers below are post the externally-funded exit accounting fix that
-# subtracts the put entry cost from cash at exit (so lifetime cash flow
-# per trade equals realized P&L, not full proceeds). The pre-fix engine
-# treated proceeds as pure profit and inflated returns by ~3-15pp
-# depending on budget; see CHANGELOG.md for details.
+# Numbers below are post TWO engine fixes (see CHANGELOG.md):
+#   1. externally-funded exit accounting — subtract put entry cost from cash at
+#      exit so lifetime per-trade cash flow equals realized P&L, not full
+#      proceeds; and
+#   2. intrinsic value computed from the UNADJUSTED close (raw strikes vs
+#      adjusted spot previously manufactured phantom intrinsic value for
+#      expired contracts).
+# With both fixes the deep-OTM overlay TRACKS SPY with a small monotonic drag
+# and a Sharpe essentially equal to buy-and-hold — the earlier "overlay beats
+# SPY / Sharpe sweet spot" result was an artifact of those two bugs.
 
 SPITZNAGEL_SPY_BASELINE = {
     "annual": 10.65,
     "max_dd": -51.9,
 }
 
-# Spitznagel framing (100% stocks + external put budget on top), engine
+# Spitznagel framing (100% stocks + external annual put budget on top), engine
 # post-fix. Tolerance: 0.5pp annual return, 1.0pp max DD, 0.05 Sharpe.
 SPITZNAGEL_TABLE = {
-    0.005: {"annual": 10.52, "max_dd": -47.05, "sharpe": 0.561},
-    0.010: {"annual": 10.11, "max_dd": -45.11, "sharpe": 0.438},
-    0.020: {"annual":  8.71, "max_dd": -65.15, "sharpe": 0.257},
-    0.033: {"annual":  5.81, "max_dd": -80.19, "sharpe": 0.124},
+    0.005: {"annual": 10.50, "max_dd": -51.9, "sharpe": 0.535},
+    0.010: {"annual": 10.34, "max_dd": -51.7, "sharpe": 0.538},
+    0.020: {"annual":  9.99, "max_dd": -51.4, "sharpe": 0.536},
+    0.033: {"annual":  9.52, "max_dd": -51.1, "sharpe": 0.525},
 }
 
 INITIAL_CAPITAL = 1_000_000
@@ -126,12 +133,15 @@ def _run_spitznagel(options_data, stocks_data, schema, budget_pct):
         {"stocks": 1.0, "options": 0.0, "cash": 0.0},
         initial_capital=INITIAL_CAPITAL,
     )
-    bt.options_budget_pct = budget_pct
+    # Annual budget framing (matches the article's "X%/yr") with daily exit
+    # checks so puts close at real bids near DTE 14 rather than expiring into
+    # the intrinsic fallback.
+    bt.options_budget_annual_pct = budget_pct
     bt.stocks = [Stock("SPY", 1.0)]
     bt.stocks_data = stocks_data
     bt.options_data = options_data
     bt.options_strategy = _make_deep_otm_put_strategy(schema)
-    bt.run(rebalance_freq=1, rebalance_unit="BMS")
+    bt.run(rebalance_freq=1, rebalance_unit="BMS", check_exits_daily=True)
     return bt.balance
 
 
@@ -146,6 +156,13 @@ def _compute_stats(balance):
     cummax = bal.cummax()
     max_dd = ((bal - cummax) / cummax).min() * 100
     return annual, max_dd, sharpe
+
+
+def _spy_series(stocks_data):
+    """SPY adjusted-close series indexed by date (buy-and-hold baseline)."""
+    df = stocks_data._data.sort_values("date")
+    df = df[df["symbol"] == "SPY"]
+    return df.set_index("date")["adjClose"]
 
 
 @requires_data
@@ -194,71 +211,74 @@ def test_spitznagel_framing(options_data, stocks_data, budget):
 
 
 @requires_data
-def test_spitznagel_sweet_spot_shape(options_data, stocks_data):
-    """The article's central qualitative claim: Sharpe peaks near 0.5%-1.0%
-    budget and degrades on either side. If the engine ever lets a budget
-    above 1% produce a higher Sharpe than the 0.5%-1.0% range, the
-    article's sweet-spot framing breaks and the test should catch it.
+def test_spitznagel_monotone_drag_and_tracking(options_data, stocks_data):
+    """Corrected qualitative shape (post exit-accounting + unadjusted-intrinsic
+    fixes): under realistic accounting the deep-OTM overlay has NO Sharpe
+    sweet spot. A larger annual put budget is a larger premium drag, so annual
+    return decreases monotonically with budget, while Sharpe stays essentially
+    equal to buy-and-hold (the puts neither add meaningful alpha nor move the
+    full-period risk-adjusted return at these budgets). The pre-fix "Sharpe
+    peaks at 0.5%-1.0%" claim was an artifact of treating put proceeds as pure
+    profit; if it reappears, an accounting regression has crept back in.
     """
     schema = options_data.schema
-    sharpes = {}
+    spy_sharpe = _compute_stats(_spy_series(stocks_data).to_frame("total capital"))[2]
+
+    annuals, sharpes = {}, {}
     for budget in (0.005, 0.010, 0.020, 0.033):
         balance = _run_spitznagel(options_data, stocks_data, schema, budget)
-        _, _, sharpe = _compute_stats(balance)
-        sharpes[budget] = sharpe
+        annual, _, sharpe = _compute_stats(balance)
+        annuals[budget], sharpes[budget] = annual, sharpe
 
-    assert sharpes[0.005] > sharpes[0.020], (
-        f"Sharpe at 0.5% ({sharpes[0.005]:.3f}) should exceed "
-        f"Sharpe at 2.0% ({sharpes[0.020]:.3f}); sweet-spot shape lost"
-    )
-    assert sharpes[0.010] > sharpes[0.033], (
-        f"Sharpe at 1.0% ({sharpes[0.010]:.3f}) should exceed "
-        f"Sharpe at 3.3% ({sharpes[0.033]:.3f}); sweet-spot shape lost"
-    )
+    budgets = [0.005, 0.010, 0.020, 0.033]
+    for lo, hi in zip(budgets, budgets[1:]):
+        assert annuals[lo] > annuals[hi], (
+            f"annual return should fall as budget rises (premium drag): "
+            f"{lo*100:.1f}% gave {annuals[lo]:.2f}% but {hi*100:.1f}% gave "
+            f"{annuals[hi]:.2f}%"
+        )
+    for budget, sharpe in sharpes.items():
+        assert abs(sharpe - spy_sharpe) < SHARPE_TOLERANCE, (
+            f"Sharpe at {budget*100:.1f}% ({sharpe:.3f}) should track SPY "
+            f"({spy_sharpe:.3f}) within {SHARPE_TOLERANCE} — no sweet spot"
+        )
 
 
 # --- Fast smoke variant -----------------------------------------------------
 # The tests above need the full 17-year SPY chain and take ~3 minutes to run.
-# This fast variant runs only the 0.5% Spitznagel budget against the full
-# sample and asserts the qualitative shape — overlay beats SPY on return and
-# Sharpe — without pinning specific numbers. Suitable as a pre-commit /
-# fast-CI smoke that catches "Spitznagel framing fundamentally broken"
-# without paying for the full parametrized run.
+# This fast variant runs only the 0.5%/yr Spitznagel budget against the full
+# sample and asserts the corrected qualitative shape — overlay TRACKS SPY on
+# return and is no worse on max drawdown — without pinning specific numbers.
+# Suitable as a pre-commit / fast-CI smoke that catches "Spitznagel framing
+# fundamentally broken" without paying for the full parametrized run.
 
 @requires_data
 @pytest.mark.smoke
 def test_spitznagel_smoke_qualitative(options_data, stocks_data):
-    """Single-budget qualitative check: 0.5% deep OTM tracks SPY on annual
-    return (within 0.5pp) and improves max drawdown by at least 3pp.
-    Catches engine-side regressions that flip the sign of the trade or
-    dramatically change the cost of protection.
+    """Single-budget qualitative check: 0.5%/yr deep OTM tracks SPY on annual
+    return (within 1pp) and is no worse than SPY on full-period max drawdown.
 
-    The fixed engine no longer produces "Spitznagel beats SPY on
-    return" under realistic accounting — the headline number from the
-    pre-fix article was an artifact of treating put proceeds as pure
-    profit. What remains true: drawdown improvement during catastrophes
-    is real and the strategy tracks the underlying closely.
+    Under realistic accounting (exit-cost and unadjusted-intrinsic fixes) the
+    overlay neither beats SPY on return nor materially improves the full-period
+    max drawdown at a 0.5%/yr budget — the pre-fix "beats SPY / big drawdown
+    improvement" headline was an artifact of phantom put proceeds. What remains
+    true and worth guarding: the strategy tracks the underlying closely and
+    does not silently flip into a return- or risk-destroying regime.
     """
     schema = options_data.schema
 
-    # SPY baseline
-    df = stocks_data._data.sort_values("date")
-    df = df[df["symbol"] == "SPY"]
-    series = df.set_index("date")["adjClose"]
-    years = (series.index[-1] - series.index[0]).days / 365.25
-    spy_annual = ((series.iloc[-1] / series.iloc[0]) ** (1 / years) - 1) * 100
-    spy_cummax = series.cummax()
-    spy_max_dd = ((series - spy_cummax) / spy_cummax).min() * 100
+    series = _spy_series(stocks_data)
+    spy_annual, spy_max_dd, _ = _compute_stats(series.to_frame("total capital"))
 
-    # 0.5% Spitznagel overlay
+    # 0.5%/yr Spitznagel overlay
     balance = _run_spitznagel(options_data, stocks_data, schema, 0.005)
     annual, max_dd, _ = _compute_stats(balance)
 
     assert abs(annual - spy_annual) < 1.0, (
-        f"0.5% Spitznagel annual ({annual:.2f}%) should track "
+        f"0.5%/yr Spitznagel annual ({annual:.2f}%) should track "
         f"SPY annual ({spy_annual:.2f}%) within 1pp"
     )
-    assert max_dd > spy_max_dd + 3.0, (  # less negative is better
-        f"0.5% Spitznagel max DD ({max_dd:.1f}%) should be at least "
-        f"3pp less severe than SPY max DD ({spy_max_dd:.1f}%)"
+    assert max_dd > spy_max_dd - 0.5, (  # less negative is better
+        f"0.5%/yr Spitznagel max DD ({max_dd:.1f}%) should be no worse "
+        f"than SPY max DD ({spy_max_dd:.1f}%)"
     )


### PR DESCRIPTION
## Summary
Fixes two acute backtest-correctness bugs uncovered after the "free puts" exit-accounting fix (`8e1f11e`), re-pins the Spitznagel reproduction to the corrected reality, and adds optional runtime invariants guarding both bug classes.

## Commits
1. **Fix option intrinsic valuation (bug B) + honor `check_exits_daily`** — unquoted contracts marked from the *unadjusted* close (adjusted spot vs raw strikes manufactured phantom intrinsic for expired puts); `engine.check_exits_daily = True` is no longer silently ignored.
2. **Re-pin Spitznagel reproduction to true-annual budget framing** — switch to `options_budget_annual_pct` + daily exits. Under the corrected engine the deep-OTM overlay **tracks SPY** (10.50% vs 10.65% at 0.5%/yr) with a small monotonic drag and Sharpe ≈ buy-and-hold; the prior "beats SPY / Sharpe sweet spot" result was an artifact of the two bugs.
3. **Add `assert_invariants` runtime self-checks** — class A (cash-flow) and class B (valuation) guards, off by default, exercised by `tests/bench/test_invariants.py::TestRuntimeInvariantChecks`.

## Verification
- Rust unit tests: 98/98
- Full Python suite: 1266 passed, 1 skipped
- Article reproduction: 7/7 on corrected annual numbers
- Invariant bench: 5/5 (no false-positives across budget regimes)

## Behavioral impact
Configs that reach the intrinsic fallback (profit-taking, shorter DTE, near-ATM, or `check_exits_daily=False`) lose phantom value. The article's deep-OTM config is largely unaffected. See CHANGELOG behavioral-changes entries.
