### PR TITLE
Fix: stop dropping filter columns before Rust dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,21 @@ anchored on the commit hash that introduced the change.
   never passed through from `BacktestEngine`, so it was dead. Exposed as
   `BacktestEngine.rebalance_stocks_on_exit` (default ``False``; only
   meaningful with `check_exits_daily=True`).
+- **Filter columns ``underlying_last``, ``impliedvol``, and
+  ``open_interest`` are no longer silently dropped before Rust
+  dispatch.** ``_run_rust`` and ``_run_rust_multi`` previously dropped
+  these three options-dataframe columns "to reduce Arrow conversion
+  cost." That broke every leg filter referencing them: strike-based
+  OTM filters (``schema.strike <= schema.underlying_last * X``)
+  silently matched zero rows so no entries fired at all; IV- and
+  OI-based filters raised ``RuntimeError: unable to find column …``.
+  Silently broke every preset whose depth filter expressed OTM as a
+  multiple of spot — ``near_atm_put_protection``, ``Strangle``,
+  ``IronCondor``, ``CoveredCall``, ``CashSecuredPut``, ``Collar``,
+  ``Butterfly``. The ``deep_otm_put`` preset was not affected because
+  it filters by delta. The drop set is now ``{"last", "optionalias"}``
+  (only columns that no filter or selector inspects). On the 17-year
+  SPY parquet, conversion cost is unchanged within noise.
 
 ### Invariants / defense-in-depth
 - **Optional runtime self-checks (`assert_invariants`).** New

--- a/options_portfolio_backtester/engine/engine.py
+++ b/options_portfolio_backtester/engine/engine.py
@@ -464,11 +464,13 @@ class BacktestEngine:
         exp_col = self._options_schema["expiration"]
 
         # Drop columns Rust never accesses to reduce Arrow conversion cost.
-        _drop_cols = {"underlying_last", "last", "optionalias", "impliedvol"}
-        # Also drop openinterest unless MaxOpenInterest selector is in use
-        if not (hasattr(self.signal_selector, '__class__')
-                and self.signal_selector.__class__.__name__ == 'MaxOpenInterest'):
-            _drop_cols.add("openinterest")
+        # Keep underlying_last, impliedvol, openinterest — they can appear in
+        # leg filters (strike <= underlying_last * X, impliedvol-based entries,
+        # OI-based selectors). Dropping them silently broke any strategy that
+        # referenced them with a "column not found" Rust error rather than a
+        # clear API error. The only safe drops are columns that no filter or
+        # selector ever inspects.
+        _drop_cols = {"last", "optionalias"}
         opts_df = self._options_data._data
         to_drop = [c for c in _drop_cols if c in opts_df.columns]
         opts_src = opts_df.drop(columns=to_drop) if to_drop else opts_df
@@ -629,8 +631,10 @@ class BacktestEngine:
         opts_date_col = self._options_schema["date"]
         stocks_date_col = self._stocks_schema["date"]
 
-        # Drop unused columns for Arrow conversion speed
-        _drop_cols = {"underlying_last", "last", "optionalias", "impliedvol"}
+        # Drop unused columns for Arrow conversion speed. Keep underlying_last,
+        # impliedvol, openinterest — see comment in _run_rust for why dropping
+        # them silently broke filter columns and selectors.
+        _drop_cols = {"last", "optionalias"}
         opts_df = self._options_data._data
         to_drop = [c for c in _drop_cols if c in opts_df.columns]
         opts_src = opts_df.drop(columns=to_drop) if to_drop else opts_df


### PR DESCRIPTION
## Summary

- `_run_rust` and `_run_rust_multi` were unconditionally dropping `underlying_last`, `impliedvol`, and `openinterest` from the options dataframe before Rust dispatch.
- That broke every leg filter that referenced these columns. Strike-based OTM filters (e.g. `schema.strike <= schema.underlying_last * 0.65`) silently matched zero rows, producing empty backtests rather than a clear error.
- Affected presets: `near_atm_put_protection`, `Strangle`, `IronCondor`, `CoveredCall`, `CashSecuredPut`, `Collar`, `Butterfly` — every preset whose depth filter multiplies by spot. The `deep_otm_put` preset was unaffected (filters by delta).
- Fix: only drop `{last, optionalias}` — columns that no filter or selector inspects.

## Test plan

- [x] tests/test_article_reproduction.py (uses delta-based filter): 7/7 pass unchanged
- [x] Manual verification: each schema column produces entries in a filter; strike <= underlying_last * 0.65 now produces 200 entries (was 0).
- [x] CHANGELOG entry under "Bug fixes"