### PR TITLE
Independent exit-price envelope oracle; repro window clamp; README benchmark fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,24 @@ anchored on the commit hash that introduced the change.
   SPY parquet, conversion cost is unchanged within noise.
 
 ### Invariants / defense-in-depth
+- **Exit-price envelope oracle (independent class-B check).**
+  ``tests/bench/test_invariants.py::TestExitPriceEnvelope`` reconstructs,
+  in pandas directly from the raw CSVs, the price bound every trade-log
+  exit must satisfy: quoted contracts must exit inside the day's
+  [bid, ask]; unquoted (expired/missing) contracts must exit at no more
+  than intrinsic computed from the *unadjusted* close. Unlike the
+  in-engine ``assert_invariants`` class-B guard — which recomputes
+  intrinsic via the same helpers the engine uses and is therefore blind
+  to a bug inside them — this oracle shares no code with the engine, so
+  the pre-fix adjClose phantom pricing fails it no matter where in the
+  engine the wrong price originates. The test also asserts both branches
+  (quoted and fallback) are actually exercised, so it cannot silently
+  become vacuous.
+- **Article-reproduction fixtures clamp to the declared data window.**
+  The pinned tables are only valid for 2008-01-02..2024-12-31; the
+  fixtures now filter the loaded data to that window, so fetching a
+  longer range with ``fetch_data.py`` can no longer shift the pinned
+  numbers and masquerade as an engine regression.
 - **`BacktestEngine` rejects unknown attributes.** The engine is sealed
   after ``__init__``: assigning an attribute it doesn't declare raises
   ``AttributeError`` (with a did-you-mean suggestion) instead of becoming

--- a/README.md
+++ b/README.md
@@ -170,11 +170,14 @@ Required: the backtest engine imports the Rust core at load time, so it must be 
 make rust-build
 ```
 
-| Benchmark | Python | Rust |
-|-----------|--------|------|
-| Full options backtest (24.7M rows) | 10.0s | **4.2s** |
-| Stock-only monthly rebalance | 3.7s | **0.6s** |
-| Parallel grid sweep (100 configs) | — | **5-8x** faster (Rayon, bypasses GIL) |
+| Benchmark | Time |
+|-----------|------|
+| Full options backtest (17-year SPY chain, ~22M rows) | ~4s |
+| Stock-only monthly rebalance | ~0.6s |
+| Parallel grid sweep (100 configs) | 5-8x vs sequential (Rayon, bypasses GIL) |
+
+(The former Python-engine comparison column was removed along with the
+Python engine path itself; those numbers are no longer reproducible.)
 
 ## Data
 

--- a/tests/bench/test_invariants.py
+++ b/tests/bench/test_invariants.py
@@ -269,3 +269,106 @@ class TestRuntimeInvariantChecks:
         eng.options_budget_pct = 0.033
         eng.run(rebalance_freq=1, rebalance_unit="BMS", check_exits_daily=False)
         assert len(eng.balance) > 1
+
+
+class TestExitPriceEnvelope:
+    """Truly independent class-B oracle (no shared code with the engine).
+
+    Every exit in the trade log must price inside the day's quote envelope,
+    reconstructed here in pandas directly from the raw CSVs:
+
+    - contract quoted on exit date (non-null bid) -> exit price within
+      [min(bid, ask), max(bid, ask)];
+    - contract unquoted (expired / missing / null bid) -> exit price no
+      greater than intrinsic value computed from the UNADJUSTED close.
+
+    The in-engine class-B invariant recomputes intrinsic via the same
+    helpers the engine uses, so a bug inside those helpers passes it. This
+    test rebuilds the bound from the raw data instead — the pre-fix
+    adjClose bug (phantom intrinsic ~ strike-minus-adjusted-spot) fails it
+    immediately, no matter where in the engine the wrong price came from.
+    """
+
+    SPC = 100
+
+    @pytest.fixture(scope="class")
+    def envelope_run(self):
+        opts = _Opts(_SPY_OPTS)
+        stx = _Stx(_SPY_STX)
+        eng = BacktestEngine(
+            {"stocks": 1.0, "options": 0.0, "cash": 0.0},
+            initial_capital=1_000_000,
+            cost_model=NoCosts(),
+            fill_model=MarketAtBidAsk(),
+        )
+        # Per-rebalance budget, NO daily exits: contracts routinely expire
+        # before the next rebalance, so the intrinsic fallback is exercised
+        # heavily — the exact regime where the adjClose bug lived.
+        eng.options_budget_pct = 0.033
+        eng.stocks = [_Stock("SPY", 1.0)]
+        eng.stocks_data = stx
+        eng.options_data = opts
+        eng.options_strategy = _deep_otm_put(opts.schema)
+        eng.run(rebalance_freq=1, rebalance_unit="BMS", check_exits_daily=False)
+        return eng, opts, stx
+
+    @_needs_spy
+    def test_every_exit_prices_inside_envelope(self, envelope_run):
+        eng, opts, stx = envelope_run
+        tl = eng.trade_log
+        exits = tl[tl[("leg_1", "order")].isin(["STC", "BTC"])]
+        assert len(exits) > 0, "no exits to check"
+
+        # Quote lookup for exited contracts only: (contract, date) -> bid, ask
+        od = opts._data
+        schema = opts.schema
+        c_col, d_col = schema["contract"], schema["date"]
+        contracts = set(exits[("leg_1", "contract")])
+        sub = od[od[c_col].isin(contracts)][[c_col, d_col, "bid", "ask"]]
+        quotes = {
+            (r[0], r[1]): (r[2], r[3])
+            for r in sub.itertuples(index=False, name=None)
+        }
+
+        # Unadjusted close by date (raw column, not DayStocks/adjClose).
+        sd = stx._data
+        spy = sd[sd[stx.schema["symbol"]] == "SPY"]
+        unadj = dict(zip(spy[stx.schema["date"]], spy["close"]))
+
+        eps = 1e-6
+        checked_quoted = checked_fallback = 0
+        for _, row in exits.iterrows():
+            # Trade-log dates are serialized as strings; quote/stock keys are
+            # Timestamps.
+            date = pd.Timestamp(row[("totals", "date")])
+            contract = row[("leg_1", "contract")]
+            strike = float(row[("leg_1", "strike")])
+            price = abs(float(row[("leg_1", "cost")])) / self.SPC
+
+            bid_ask = quotes.get((contract, date))
+            bid = bid_ask[0] if bid_ask is not None else None
+            if bid is not None and not np.isnan(bid):
+                ask = bid_ask[1]
+                hi = max(bid, ask) if not np.isnan(ask) else bid
+                lo = min(bid, ask) if not np.isnan(ask) else bid
+                assert lo - eps <= price <= hi + eps, (
+                    f"{contract} exit {date}: price {price} outside "
+                    f"quote envelope [{lo}, {hi}]"
+                )
+                checked_quoted += 1
+            else:
+                spot = float(unadj.get(date, 0.0))
+                intrinsic = max(strike - spot, 0.0)  # long puts only here
+                assert -eps <= price <= intrinsic + eps, (
+                    f"{contract} exit {date}: unquoted exit priced {price}, "
+                    f"unadjusted intrinsic bound {intrinsic} "
+                    f"(strike {strike}, raw close {spot})"
+                )
+                checked_fallback += 1
+
+        # The oracle is only meaningful if both branches were exercised.
+        assert checked_quoted > 0, "no quoted exits checked"
+        assert checked_fallback > 0, (
+            "no intrinsic-fallback exits occurred — config no longer "
+            "exercises the regime the adjClose bug lived in"
+        )

--- a/tests/test_article_reproduction.py
+++ b/tests/test_article_reproduction.py
@@ -30,6 +30,7 @@ import warnings
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 warnings.filterwarnings("ignore")
@@ -89,14 +90,30 @@ DRAWDOWN_TOLERANCE_PP = 1.0
 SHARPE_TOLERANCE = 0.05
 
 
+# The pinned tables above are only valid for this exact window. Clamp the
+# loaded data to it so fetching a longer range (e.g. `fetch_data.py` with a
+# later --end) cannot masquerade as an engine regression — an extra year of
+# data once shifted the most-leveraged row past tolerance and looked exactly
+# like a backtest bug.
+ARTICLE_WINDOW_END = pd.Timestamp("2024-12-31")
+
+
 @pytest.fixture(scope="module")
 def options_data():
-    return HistoricalOptionsData(str(OPTIONS_CSV))
+    d = HistoricalOptionsData(str(OPTIONS_CSV))
+    date_col = d.schema["date"]
+    d._data = d._data[d._data[date_col] <= ARTICLE_WINDOW_END]
+    d.end_date = d._data[date_col].max()
+    return d
 
 
 @pytest.fixture(scope="module")
 def stocks_data():
-    return TiingoData(str(STOCKS_CSV))
+    d = TiingoData(str(STOCKS_CSV))
+    date_col = d.schema["date"]
+    d._data = d._data[d._data[date_col] <= ARTICLE_WINDOW_END]
+    d.end_date = d._data[date_col].max()
+    return d
 
 
 def _make_deep_otm_put_strategy(schema):


### PR DESCRIPTION
## Summary
Three follow-ups from the defense-in-depth review:

1. **Exit-price envelope oracle** (`tests/bench/test_invariants.py::TestExitPriceEnvelope`) — a truly independent class-B check. Reconstructs in pandas, from the raw CSVs, the bound every trade-log exit must satisfy: quoted → inside the day's [bid, ask]; unquoted → ≤ unadjusted-close intrinsic. Shares no code with the engine (the in-engine class-B guard recomputes intrinsic via the same helpers it guards, so it can't see a bug inside them). Asserts both branches are exercised, so it can't silently become vacuous. The pre-fix adjClose phantom pricing fails it regardless of where the wrong price originates.
2. **Repro window clamp** — fixtures filter data to the declared 2008–2024 window, so fetching a longer range can't shift the pinned tables and masquerade as an engine regression (this exact false-failure happened with 2025 data).
3. **README** — drop the benchmark column comparing against the removed Python engine; those numbers are no longer reproducible.

## Verification
- Envelope oracle: passes, with both quoted and fallback branches exercised
- Article reproduction: 7/7 with clamped fixtures
- Full default suite: 1274 passed, 1 skipped
