### PR TITLE
fetch_data: keep parquet outputs in sync with date alignment

### DIFF
--- a/data/fetch_data.py
+++ b/data/fetch_data.py
@@ -416,6 +416,14 @@ def align_dates(stocks_path, options_path):
     stocks_filtered.to_csv(stocks_path, index=False)
     options_filtered.to_csv(options_path, index=False)
 
+    # Keep the parquet twins in sync. The engine asserts stock/option date
+    # alignment at run(), and parquet is the recommended fast load path —
+    # leaving it unaligned makes every parquet-based run fail that assert.
+    for path, df in ((stocks_path, stocks_filtered), (options_path, options_filtered)):
+        pq = Path(path).with_suffix(".parquet")
+        if pq.exists():
+            df.to_parquet(pq, index=False)
+
     dropped_stock = len(stocks) - len(stocks_filtered)
     dropped_opt = len(options) - len(options_filtered)
     print(f"Aligned dates: {len(shared)} shared trading days")


### PR DESCRIPTION
align_dates() rewrote only the CSVs; the parquet twins kept rows on dropped dates, so every parquet-based run after a fresh fetch failed the engine's date-alignment assert — including research/spitznagel_spy/reproduce_article.py. Now the filtered frames are also written to the sibling .parquet files. Verified: parquet+csv aligned (4275=4275 dates), reproduce_article.py runs end-to-end, and the headline table reproduces exactly with assert_invariants=True.